### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -33,7 +33,7 @@ jobs:
         draft: false
         prerelease: false
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: tiger12055/dropout-predictions # CHANGE THIS to your DockerHub username and repository!
         username: ${{ secrets.DOCKER_USERNAME }} # you need to add your Docker username to this GitHub repo as a secret


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore